### PR TITLE
fix: Correct case view and person view

### DIFF
--- a/routes/cases.js
+++ b/routes/cases.js
@@ -75,6 +75,16 @@ router.get('/:id', async (req, res) => {
       bailDecisions: true,
       warrants: true,
       searchWarrants: true,
+      lawyers: {
+        include: {
+          visits: true,
+        },
+      },
+      medicalRecords: {
+        include: {
+          medications: true,
+        },
+      },
     },
   });
   const user = await prisma.user.findUnique({

--- a/views/people/show.ejs
+++ b/views/people/show.ejs
@@ -51,64 +51,6 @@
         <% }) %>
       </ul>
 
-      <h3 class="text-xl font-bold text-gray-800 mt-8 mb-4">Legal Representation</h3>
-      <% person.bookings.forEach(booking => { %>
-        <% if (booking.case) { %>
-        <div class="border-b border-gray-200 py-4">
-          <h4 class="font-bold">Case #<%= booking.case.caseNumber %></h4>
-          <a href="/lawyers/new/<%= booking.case.id %>" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">Add Lawyer</a>
-          <ul>
-            <% booking.case.lawyers.forEach(lawyer => { %>
-              <li class="border-b border-gray-200 py-4">
-                <p><strong>Name:</strong> <%= lawyer.name %></p>
-                <p><strong>Firm:</strong> <%= lawyer.firm %></p>
-                <p><strong>License:</strong> <%= lawyer.license %></p>
-                <a href="/lawyers/<%= lawyer.id %>/visits/new" class="text-blue-500 hover:underline">Add Visit</a>
-                <h4 class="font-bold mt-4">Visits</h4>
-                <ul>
-                  <% lawyer.visits.forEach(visit => { %>
-                    <li class="border-t border-gray-200 py-2">
-                      <p><strong>Date:</strong> <%= visit.visitDate.toLocaleString() %></p>
-                      <p><strong>Notes:</strong> <%= visit.notes %></p>
-                    </li>
-                  <% }) %>
-                </ul>
-              </li>
-            <% }) %>
-          </ul>
-        </div>
-        <% } %>
-      <% }) %>
-
-      <h3 class="text-xl font-bold text-gray-800 mt-8 mb-4">Medical Records</h3>
-      <% person.bookings.forEach(booking => { %>
-        <% if (booking.case) { %>
-        <div class="border-b border-gray-200 py-4">
-          <h4 class="font-bold">Case #<%= booking.case.caseNumber %></h4>
-          <a href="/medical-records/new/<%= booking.case.id %>" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">Add Medical Record</a>
-          <ul>
-            <% booking.case.medicalRecords.forEach(record => { %>
-              <li class="border-b border-gray-200 py-4">
-                <p><strong>Condition:</strong> <%= record.condition %></p>
-                <p><strong>Allergies:</strong> <%= record.allergies %></p>
-                <p><strong>Notes:</strong> <%= record.notes %></p>
-                <a href="/medical-records/<%= record.id %>/medications/new" class="text-blue-500 hover:underline">Add Medication</a>
-                <h4 class="font-bold mt-4">Medications</h4>
-                <ul>
-                  <% record.medications.forEach(med => { %>
-                    <li class="border-t border-gray-200 py-2">
-                      <p><strong>Medication:</strong> <%= med.medication %></p>
-                      <p><strong>Dosage:</strong> <%= med.dosage %></p>
-                      <p><strong>Frequency:</strong> <%= med.frequency %></p>
-                    </li>
-                  <% }) %>
-                </ul>
-              </li>
-            <% }) %>
-          </ul>
-        </div>
-        <% } %>
-      <% }) %>
 
       <h3 class="text-xl font-bold text-gray-800 mt-8 mb-4">Next of Kin</h3>
       <a href="/next-of-kin/new/<%= person.id %>" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">Add Next of Kin</a>


### PR DESCRIPTION
This commit fixes two issues:

- **`views/cases/show.ejs`:** The `include` statement in `routes/cases.js` has been corrected to properly fetch the `lawyers` and `medicalRecords` for each case, resolving the `TypeError` in the view.
- **`views/people/show.ejs`:** The "Medical Records" and "Legal Representation" sections have been removed from the person view to avoid confusion, as this information is now displayed in the case view.