### PR TITLE
fix: Remove deletedAt from queries

### DIFF
--- a/routes/cases.js
+++ b/routes/cases.js
@@ -41,7 +41,7 @@ router.post('/', checkRole(['Police']), async (req, res) => {
 
 router.get('/:id', async (req, res) => {
   const caseRecord = await prisma.case.findFirst({
-    where: { id: parseInt(req.params.id), deletedAt: null },
+    where: { id: parseInt(req.params.id) },
     include: {
       booking: {
         include: {

--- a/routes/people.js
+++ b/routes/people.js
@@ -32,7 +32,7 @@ router.post('/', checkRole(['Police']), upload.single('photo'), async (req, res)
 
 router.get('/:id', async (req, res) => {
   const person = await prisma.person.findFirst({
-    where: { id: parseInt(req.params.id), deletedAt: null },
+    where: { id: parseInt(req.params.id) },
     include: {
       bookings: {
         include: {


### PR DESCRIPTION
This commit removes the `deletedAt` field from the queries in the `routes/people.js` and `routes/cases.js` files. This field was removed from the database schema in a previous commit, but the queries were not updated.